### PR TITLE
✨ Add `--unfurl` flag

### DIFF
--- a/src/article.rs
+++ b/src/article.rs
@@ -12,10 +12,17 @@ pub struct Article {
     pub release_notes_url: Option<Url>,
 }
 
+impl Article {
+    /// Creates a new article.
+    pub fn release_notes_url_unfurled(&self) -> Option<Url> {
+        self.release_notes_url.as_ref()
+            .map(|url| crate::url::unfurl(url).unwrap())
+    }
+}
+
 impl Display for Article {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let url = self.release_notes_url.as_ref().map_or(None, |url| Some(url.to_string()));
-        write!(f, "{} - {}, <{}>", self.date, self.title, url.unwrap_or_default())
+        write!(f, "{} - {}", self.date, self.title)
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,21 +6,25 @@ extern crate clap;
 
 use clap::{Arg, ArgAction, Command};
 
-// #[derive(clap::Parser)]
-// struct Cli {}
-
+/// Parses command line arguments.
 pub(crate) fn cli() -> Command {
     Command::new("apple_releases")
         .about("CLI for the Apple Developer News RSS feed")
         .version("0.1.0")
         .author("Ben Chatelain")
-        .arg(
-            // --all
+        .arg( // --all
             Arg::new("all")
                 .long("all")
                 .short('a')
                 .help("Show all releases")
                 .action(ArgAction::SetTrue)
+        )
+        .arg( // --unfurl
+            Arg::new("unfurl")
+                .long("unfurl")
+                .short('u')
+                .help("Unfurl release note URLs")
+                .action(ArgAction::SetTrue),
         )
         .after_help("Longer explanation to appear after the options when \
                  displaying the help information from --help or -h")

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ lazy_static! {
 fn main() {
     let args = cli().get_matches();
     let show_all = args.get_one::<bool>("all").unwrap();
+    let unfurl_urls = args.get_one::<bool>("unfurl").unwrap();
 
     let body = url::get(APPLE_DEV_RELEASES.to_string()).unwrap();
 
@@ -43,7 +44,12 @@ fn main() {
     articles.iter().for_each(|article| {
         match article.release_notes_url {
             Some(_) => {
-                println!("{}", article);
+                print!("{}", article);
+                if *unfurl_urls {
+                    println!(" - {}", article.release_notes_url_unfurled().unwrap());
+                } else {
+                    println!(" - {}", article.release_notes_url.as_ref().unwrap());
+                }
             }
             _ => {
                 if *show_all {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -129,7 +129,7 @@ fn test_parse() {
 </section>
     "###.to_string();
 
-    let articles = parse::parse_articles(html).expect("Err collecting articles");
+    let articles = parse_articles(html).expect("Err collecting articles");
     assert_eq!(articles.len(), 1);
 }
 
@@ -146,7 +146,7 @@ fn test_parse_title() {
     let element = fragment.select(&selector).next().unwrap();
     println!("{}", element.inner_html());
 
-    let title = parse::parse_article_title(&fragment.root_element(), &SELECTORS.title).unwrap();
+    let title = parse_article_title(&fragment.root_element(), &SELECTORS.title).unwrap();
 
     assert_eq!(title, "Xcode 14 beta 5 (14A5294e)");
 }
@@ -164,7 +164,7 @@ fn test_parse_date() {
     let element = fragment.select(&selector).next().unwrap();
     println!("{}", element.inner_html());
 
-    let date = parse::parse_article_date(&fragment.root_element(), &SELECTORS.date).unwrap();
+    let date = parse_article_date(&fragment.root_element(), &SELECTORS.date).unwrap();
 
     assert_eq!(date, "August 8, 2022");
 }
@@ -189,7 +189,7 @@ fn test_parse_release_notes_link() {
     // .to_string()
     println!("{}", element.attr("href").unwrap());
 
-    let notes_url = parse::parse_release_notes_link(&fragment.root_element(), &SELECTORS.release_notes_short_url).unwrap();
+    let notes_url = parse_release_notes_link(&fragment.root_element(), &SELECTORS.release_notes_short_url).unwrap();
 
     assert_eq!(notes_url, "/go/?id=xcode-14-sdk-rn");
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,8 +26,7 @@ pub fn parse_articles(content: String) -> GenericResult<Vec<Article>> {
         let notes = parse_release_notes_link(&container, &SELECTORS.release_notes_short_url);
         let notes_url = crate::url::build_notes_url(notes)
             // Ignore Transporter app store links
-            .filter(|url| url.as_str().contains("developer.apple.com"))
-            .map(|url| crate::url::unfurl(url).unwrap());
+            .filter(|url| url.as_str().contains("developer.apple.com"));
 
         // TODO: Log debug
         // let url = notes_url.as_ref().map_or(None, |url| Some(url.to_string()));

--- a/src/url.rs
+++ b/src/url.rs
@@ -37,7 +37,7 @@ pub fn get(url: String) -> GenericResult<String> {
 /// # Arguments
 ///
 /// - `url` - The URL at the end of a redirect chain.
-pub(crate) fn unfurl(url: Url) -> GenericResult<Url> {
+pub(crate) fn unfurl(url: &Url) -> GenericResult<Url> {
     let body = crate::url::get(url.to_string()).unwrap();
     let document = Html::parse_document(&body);
 


### PR DESCRIPTION
Release notes URLs are only unfurled when the `--unfurl` flag is present. This speeds up display by greatly reducing HTTP requests